### PR TITLE
cleanup of http serfver

### DIFF
--- a/Hails.hs
+++ b/Hails.hs
@@ -1,13 +1,12 @@
-import Hails.Utils.TCB
+import Hails.TCB.Load
 import Hails.HttpServer
 import Data.IterIO.Server.TCPServer
 import System.Environment
 
 main :: IO ()
 main = do
-	env <- getEnvironment
-	let port = maybe 8080 read (lookup "PORT" env)
-	let appName = maybe "App" id (lookup "APP_NAME" env)
-	func <- loadApp appName
-	runTCPServer $ secureHttpServer (fromInteger port) func
-
+  env <- getEnvironment
+  let port = maybe 8080 read (lookup "PORT" env)
+  let appName = maybe "App" id (lookup "APP_NAME" env)
+  func <- loadApp appName
+  runTCPServer $ secureHttpServer (fromInteger port) func

--- a/Hails/App.hs
+++ b/Hails/App.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE CPP #-}
+#if __GLASGOW_HASKELL__ >= 702
+{-# LANGUAGE Trustworthy #-}
+#endif
+module Hails.App ( module Hails.IterIO.HailsRoute
+                 , module Data.IterIO.Http.Support.RestController
+                 , module Data.IterIO.Http.Support.Routing
+                 , module Data.IterIO.Http
+                 , module LIO
+                 , module LIO.DCLabel
+                 , AppReqHandler, AppRoute
+                 ) where
+
+import Hails.IterIO.HailsRoute
+import Data.IterIO.Http.Support.RestController
+import Data.IterIO.Http.Support.Routing
+import Data.IterIO.Http
+import LIO
+import LIO.DCLabel
+import Hails.TCB.Types ( AppReqHandler, AppRoute )

--- a/Hails/Database.hs
+++ b/Hails/Database.hs
@@ -5,7 +5,7 @@ module Hails.Database ( withDB, databases ) where
 import LIO.MonadCatch
 import LIO.DCLabel
 import Data.String.Utils
-import Hails.Utils.TCB
+import Hails.TCB.Load ( loadDatabase )
 import Hails.Database.MongoDB (DCAction)
 import Hails.Database.MongoDB.TCB.Types
 import Hails.Database.MongoDB.TCB.DCAccess (dcAccess)

--- a/Hails/Database/MongoDB/TCB/DCAccess.hs
+++ b/Hails/Database/MongoDB/TCB/DCAccess.hs
@@ -1,3 +1,7 @@
+{-# LANGUAGE CPP #-}
+#if __GLASGOW_HASKELL__ >= 704
+{-# LANGUAGE Unsafe #-}
+#endif
 {-# LANGUAGE FlexibleContexts #-}
 module Hails.Database.MongoDB.TCB.DCAccess ( DBConf(..)
                                            , DCAction
@@ -49,6 +53,7 @@ dcAccess db act = do
 
 -- | The @withDB@ functions should use this function to label
 -- their databases.
+-- TODO (DS/AL(: make every searchable field indexable.
 labelDatabase :: DBConf  -- ^ Database configuratoin
               -> DCLabel -- ^ Label of collection policies
               -> DCLabel -- ^ Database label

--- a/Hails/HttpServer.hs
+++ b/Hails/HttpServer.hs
@@ -9,58 +9,104 @@ module Hails.HttpServer ( secureHttpServer ) where
 
 import Data.ByteString.Base64
 import qualified Data.ByteString.Lazy.Char8 as L
-import qualified Data.ByteString.Char8 as S
+import qualified Data.ByteString.Char8 as C
+
 import Data.IterIO
 import Data.IterIO.Http
 import Data.IterIO.Server.TCPServer
-import DCLabel.TCB
+import Data.Functor ((<$>))
+
+import Hails.TCB.Types
+
 import Hails.IterIO.Conversions
+import DCLabel.TCB
 import LIO.DCLabel
 import LIO.MonadLIO hiding (liftIO)
 import LIO.TCB
 import Network.Socket as Net
 
-userFromAuthCode :: Maybe S.ByteString -> Maybe String
-userFromAuthCode mAuthCode = fmap extractUser mAuthCode
-  where extractUser b64u = S.unpack $ S.takeWhile (/= ':') $ decodeLenient b64u
 
-replace :: (a -> Bool) -> a -> [a] -> [a]
-replace f a (x:xs) | f x = a:(replace f a xs)
-                 | otherwise = x:(replace f a xs)
-replace _ _ [] = []
+lpub :: DCLabel
+lpub = newDC (<>) (<>)
 
-httpApp :: (DCPrivTCB -> HttpRequestHandler DC ())
-        -> Inum L.ByteString L.ByteString DC ()
+-- | Given an 'App' return handler.
+httpApp :: AppReqHandler -> Inum L.ByteString L.ByteString DC ()
 httpApp lrh = mkInumM $ do
-  req <- httpReqI
-  case userFromAuthCode (fmap (S.drop 6) $ Prelude.lookup "authorization" (reqHeaders req)) of
-    Just user -> do
-      liftLIO $ taint $ newDC (<>) (<>)
-      let l = newDC user (<>)
-      liftLIO $ lowerClr l
-      let pathPrefix = takeWhile (/= '.') $ S.unpack $ reqHost req
-      let privilege = createPrivTCB $ newPriv pathPrefix
-      let resultReq = req {
-        reqHeaders = replace ((== "authorization") . fst) ("authorization", S.pack user) $
-                      reqHeaders req
-      }
-      resp <- liftI $ inumHttpBody req .| lrh privilege resultReq
+  req0 <- httpReqI
+  appState <- getAppConf req0
+  case appState of
+    Left resp -> irun $ enumHttpResp resp Nothing
+    Right appC -> do
+      let userLabel = newDC (appUser appC) (<>)
+          req = appReq appC
+      -- Set current label to be public, clearance to the user's label
+      -- and privilege to the app's privilege.
+      liftLIO $ do taint lpub 
+                   lowerClr userLabel
+                   setPrivileges (appPriv appC)
+      -- TODO: catch exceptions
+      resp <- liftI $ inumHttpBody req .| lrh req
       resultLabel <- liftLIO $ getLabel
-      if resultLabel `leq` l then
-        irun $ enumHttpResp resp Nothing
-        else
-          irun $ enumHttpResp (mkHttpHead stat500) Nothing
-    Nothing -> do
-      let authRequired = mkHttpHead stat401
-      irun $ enumHttpResp (authRequired
-        { respHeaders = "WWW-Authenticate: Basic realm=\"Hails\"":(respHeaders authRequired)})
-        Nothing
+      irun $ (flip enumHttpResp) Nothing $ 
+        if resultLabel `leq` userLabel
+          then resp 
+          else resp500 "App violated IFC" --TODO: add custom header
 
-secureHttpServer :: PortNumber -> (DCPrivTCB -> HttpRequestHandler DC ()) -> TCPServer L.ByteString DC
+-- | Return a server, given a port number and app.
+secureHttpServer :: PortNumber -> AppReqHandler -> TCPServer L.ByteString DC
 secureHttpServer port lrh = TCPServer port (httpApp lrh) dcServerAcceptor
   (\m -> fmap fst $ evalDC m)
 
+-- | Given a socket, return the to/from-browser pipes.
 dcServerAcceptor :: Net.Socket -> DC (Iter L.ByteString DC (), Onum L.ByteString DC ())
 dcServerAcceptor sock = do
   (iterIO, onumIO) <- ioTCB $ defaultServerAcceptor sock
   return (iterIOtoIterLIO iterIO, onumIOtoOnumLIO onumIO)
+
+--
+-- Helper
+--
+
+-- | Get the authenticated user, application name, and new (safe)
+-- request.
+getAppConf :: (Monad m, Monad m')
+            => HttpReq ()
+            -> m (Either (HttpResp m') AppConf)
+getAppConf req0 = do
+  authRes <- tryAuthUser req0
+  case authRes of
+    Left resp -> return . Left $ resp
+    Right (user, req) ->
+      let u = principal $ user
+          n = C.unpack $ C.takeWhile (/= '.') $ reqHost req
+          p = createPrivTCB $ newPriv n
+      in return . Right $ AppConf { appUser = u
+                                  , appName = n
+                                  , appPriv = p
+                                  , appReq  = req }
+
+
+-- | Get the authenticated user information and remove and sensitive
+-- headers from request.
+tryAuthUser :: (Monad m, Monad m')
+            => HttpReq s
+            -> m (Either (HttpResp m') (C.ByteString, HttpReq s))
+tryAuthUser req = do
+  case userFromReq of
+    Nothing -> return . Left $ respAuthRequired
+    Just user -> do
+        return . Right $
+          ( user, req {
+              reqHeaders = filter ((/=authField) . fst) $ reqHeaders req
+                      })
+  where authField = "authorization"
+        -- No login, send an auth response-header:
+        respAuthRequired =
+         let hdr = mkHttpHead stat401
+             authHdr = "WWW-Authenticate: Basic realm=\"Hails\""
+         in hdr { respHeaders = authHdr : (respHeaders hdr) }
+        -- Get user information from request header:
+        userFromReq  = let mAuthCode = lookup authField $ reqHeaders req
+                       in extractUser . (C.dropWhile (/= ' ')) <$> mAuthCode
+        extractUser b64u = C.takeWhile (/= ':') $ decodeLenient b64u
+

--- a/Hails/TCB/Types.hs
+++ b/Hails/TCB/Types.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE CPP #-}
+#if __GLASGOW_HASKELL__ >= 704
+{-# LANGUAGE Unsafe #-}
+#endif
+{-# LANGUAGE DeriveFunctor,
+             GeneralizedNewtypeDeriving #-}
+             
+module Hails.TCB.Types ( AppConf(..)
+                       , AppReqHandler
+                       , AppRoute
+                       ) where
+
+import Data.IterIO.Http
+import Data.IterIO.HttpRoute
+
+import DCLabel.TCB
+import LIO.DCLabel
+
+-- | Application name
+type AppName = String
+
+-- | Application configuration.
+data AppConf = AppConf { appUser :: !Principal
+                         -- ^ User the app is running on behalf of
+                         , appName :: !AppName
+                         -- ^ The app's name
+                         , appPriv :: !TCBPriv
+                         -- ^ The app's privileges.
+                         , appReq  :: HttpReq ()
+                         -- ^ The request message
+                         } deriving (Show)
+
+-- | Application handler.
+type AppReqHandler = HttpRequestHandler DC ()
+
+-- | Application route.
+type AppRoute = HttpRoute DC ()

--- a/hails.cabal
+++ b/hails.cabal
@@ -49,10 +49,12 @@ Library
     Hails.Data.LBson.Safe
     Hails.Data.LBson.TCB
 --    Hails.Network.HTTP
+    Hails.App
     Hails.HttpServer
     Hails.IterIO.Conversions
     Hails.IterIO.HailsRoute
-    Hails.Utils.TCB
+    Hails.TCB.Load
+    Hails.TCB.Types
     Hails.Database
     Hails.Database.MongoDB
     Hails.Database.MongoDB.TCB.Access


### PR DESCRIPTION
minor clean up of the loading and executing app.

The app privileges are set as the underlying privileges of the app. it is important that the app use 'dropPrivileges' when executing code it does not trust. Let's see how this plays out - it might be that this is too 'relaxed' and can lead to app authros writing code that may be exploitable by provides. E.g., as a provider I can write some malicious code that will use the underlying privileges which the app author might not have dropped. In that sense, we usually would want an app author to use withDB as follows
<pre><code>
withPrivileges noPrivs $ withDB "providerDB" $ ....
</pre></code>
