### PR TITLE
Http helpers

### DIFF
--- a/Hails/IterIO/HttpClient.hs
+++ b/Hails/IterIO/HttpClient.hs
@@ -103,7 +103,9 @@ httpRespToDC resp =
   HttpRespDC { respStatusDC  = respStatus resp
              , respHeadersDC = respHeaders resp
              , respBodyDC    = getTCB >>= \s -> 
-                return $ inumIOtoInumLIO (enumHttpResp resp) s }
+                return $ inumIOtoInumLIO enumHttpBodyResp s }
+    where enumHttpBodyResp = respBody resp |. maybeChunk
+          maybeChunk = if respChunk resp then inumToChunks else inumNop
 
 --
 -- HTTP Response


### PR DESCRIPTION
- Modified HttpRespDC: the body enumerator only enumerates the body vs. whole response
- Added helper to extract body from response.
