### PR TITLE
fix bug in findWhere; bson exports

### DIFF
--- a/Hails/Data/LBson/Rexports.hs
+++ b/Hails/Data/LBson/Rexports.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE CPP #-}
+#if __GLASGOW_HASKELL__ >= 704
+{-# LANGUAGE Trustworthy #-}
+#endif
+
+-- | Moduule rexport Bson Value value-constructors
+module Hails.Data.LBson.Rexports( Value ( Float
+                                        , String
+                                        , Doc
+                                        , Array
+                                        , Bin
+                                        , Fun
+                                        , Uuid
+                                        , Md5
+                                        , UserDef
+                                        , ObjId
+                                        , Bool
+                                        , UTC
+                                        , Null
+                                        , RegEx
+                                        , JavaScr
+                                        , Sym
+                                        , Int32
+                                        , Int64
+                                        , Stamp
+                                        , MinMax )
+                                ) where
+import Data.Bson

--- a/Hails/Data/LBson/Rexports/Bson.hs
+++ b/Hails/Data/LBson/Rexports/Bson.hs
@@ -1,0 +1,9 @@
+{-# LANGUAGE CPP #-}
+#if __GLASGOW_HASKELL__ >= 704
+{-# LANGUAGE Trustworthy #-}
+#endif
+
+-- | Rexports "Data.Bson"
+module Hails.Data.LBson.Rexports.Bson ( module Data.Bson  ) where
+
+import Data.Bson 

--- a/Hails/Data/LBson/Safe.hs
+++ b/Hails/Data/LBson/Safe.hs
@@ -11,7 +11,8 @@ module Hails.Data.LBson.Safe ( -- * UTF-8 String
                                module Data.UString
                                -- * Document
                              , Document, LabeledDocument
-                             , look, lookup, valueAt, at, include, exclude, merge
+                             , look, lookup
+                             , valueAt, at, include, exclude, merge
                                -- * Field
                              , Field(..), (=:), (=?)
                              , Key
@@ -37,10 +38,14 @@ module Hails.Data.LBson.Safe ( -- * UTF-8 String
                              , genObjectId
 
                                -- * Convert to/from "Data.Bson"
-                             , BsonValue, safeToBsonValue, safeFromBsonValue
+                             , BsonValue
+                             , module Hails.Data.LBson.Rexports
+                             , safeToBsonValue, safeFromBsonValue
                              , BsonDocument, safeToBsonDoc, safeFromBsonDoc
+                               -- * Convert to/from Bytestring
                              , encodeDoc, decodeDoc
                              ) where
-import Prelude ()
+import Prelude hiding (lookup)
 import Hails.Data.LBson.TCB
 import Data.UString
+import Hails.Data.LBson.Rexports hiding (Value)

--- a/Hails/Data/LBson/TCB.hs
+++ b/Hails/Data/LBson/TCB.hs
@@ -16,10 +16,6 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE OverlappingInstances #-}
 
---
-#define DEBUG 0
---
-
 module Hails.Data.LBson.TCB ( -- * UTF-8 String
                               module Data.UString
                               -- * Document
@@ -50,7 +46,8 @@ module Hails.Data.LBson.TCB ( -- * UTF-8 String
                             , timestamp
                             , genObjectId
                             -- * Serializing Value, converting to Bson documents
-                            , BsonValue, safeToBsonValue, safeFromBsonValue
+                            , BsonValue
+                            , safeToBsonValue, safeFromBsonValue
                             , BsonDocument, safeToBsonDoc, safeFromBsonDoc
                             , encodeDoc, decodeDoc
                             -- Unsafe converters
@@ -74,7 +71,8 @@ import Data.Bson ( Binary(..)
                  , MongoStamp(..)
                  , MinMaxKey(..)
                  , ObjectId(..)
-                 , timestamp)
+                 , timestamp
+                 )
 import Data.Bson.Binary (putDocument, getDocument)
 import Data.Binary.Get (runGet)
 import Data.Binary.Put (runPut)

--- a/Hails/Database.hs
+++ b/Hails/Database.hs
@@ -14,9 +14,10 @@ import qualified Data.UString as U
 import System.Environment
 import qualified Data.ByteString.Char8 as C
 
--- | Given a principal corresponding to the databaes owner and a
+-- | Given a principal corresponding to the database owner and a
 -- database name create the corresponding database object in @LIO@.
-loadDatabase :: DatabasePolicy dbp => Principal
+loadDatabase :: DatabasePolicy dbp
+             => Principal
              -> DatabaseName
              -> (DC dbp)
 loadDatabase dbPrincipal dbName = do

--- a/Hails/Database/MongoDB/Structured.hs
+++ b/Hails/Database/MongoDB/Structured.hs
@@ -119,7 +119,7 @@ class DCRecord a where
     result <- withDB policy $ findOneP p query
     c <- getClearance
     case result of
-      Right (Just r) | labelOf r `leq` c -> fromDocument `liftM` unlabelP p r
+      Right (Just r) | leqp p (labelOf r) c -> fromDocument `liftM` unlabelP p r
       _ -> return Nothing
   --
   deleteByP p policy colName k v = 

--- a/hails.cabal
+++ b/hails.cabal
@@ -51,6 +51,7 @@ Library
 
   Exposed-modules:
     Hails.Data.LBson
+    Hails.Data.LBson.Rexports.Bson
     Hails.Data.LBson.Safe
     Hails.Data.LBson.TCB
     Hails.App


### PR DESCRIPTION
1) fixed bug in findWhere where privs were not used when doing labelel
comparison with clearance

2) reexporting bson, as trustworthy interface
