### PR TITLE
Added non-logged-in support

### DIFF
--- a/Hails/App.hs
+++ b/Hails/App.hs
@@ -18,10 +18,10 @@ import Data.IterIO.Http.Support.Action (Action, requestHeader)
 import qualified Data.ByteString.Char8 as S8
 
 -- | Get the user the app is running on behalf of
-getHailsUser :: Action t b DC String
+getHailsUser :: Action t b DC (Maybe String)
 getHailsUser = do
   hdr <- requestHeader (S8.pack "x-hails-user")
-  maybe (fail "No x-hails-user header") (return . S8.unpack) hdr
+  return $ fmap S8.unpack hdr
 
 -- | Get the app the app is running on behalf of
 getHailsApp :: Action t b DC String

--- a/Hails/TCB/Types.hs
+++ b/Hails/TCB/Types.hs
@@ -24,7 +24,7 @@ type L = L.ByteString
 type AppName = String
 
 -- | Application configuration.
-data AppConf = AppConf { appUser :: !Principal
+data AppConf = AppConf { appUser :: !Component
                          -- ^ User the app is running on behalf of
                          , appName :: !AppName
                          -- ^ The app's name


### PR DESCRIPTION
This is my attempt at the no login required part. I think it's simpler - no mvars, nothing fancy. the app just return an unauthorized status code if they require login. We could add a library call like you did as well.
- If non-logged-in session does a request, the clearance is set to
  public
- Applications can return status 401 to require login, which will
  be translated to status 403 (Forbidden) if the user is already
  logged in
