### PR TITLE
vulnerability-fix: filter out x-hails-user

### DIFF
--- a/Hails/HttpServer/Types.hs
+++ b/Hails/HttpServer/Types.hs
@@ -4,6 +4,7 @@ module Hails.HttpServer.Types (
   -- * Requests
     Request(..)
   , getRequestBodyType, RequestBodyType(..)
+  , addRequestHeader, removeRequestHeader
   -- * Responses
   , Response(..)
   , addResponseHeader, removeResponseHeader
@@ -90,6 +91,17 @@ getRequestBodyType req = do
                         then Just $ S.drop (S.length bound') s'
                         else Nothing
             else Nothing
+
+-- | Add/replace a 'H.Header' to the 'Request'
+addRequestHeader :: Request -> H.Header -> Request
+addRequestHeader req hdr@(hname, _) = req { requestHeaders = hdr:headers }
+
+  where headers = List.filter ((/= hname) . fst) $ requestHeaders req
+-- | Remove a header (if it exists) from the 'Request'
+removeRequestHeader :: Request -> H.HeaderName -> Request
+removeRequestHeader req hname = req { requestHeaders = headers }
+  where headers = List.filter ((/= hname) . fst) $ requestHeaders req
+
 
 --
 -- Response

--- a/hails.cabal
+++ b/hails.cabal
@@ -1,5 +1,5 @@
 Name:           hails
-Version:        0.9.2.1
+Version:        0.9.2.2
 build-type:     Simple
 License:        GPL-2
 License-File:   LICENSE


### PR DESCRIPTION
We forgot to port this from the old  version of Hails.
As a result a user can just set x-hails-user and bypass any
authenticatoin.

Thanks to Jeff Seibert for finding this.
